### PR TITLE
科目名検索機能の追加

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -11,10 +11,27 @@ def health_handler(event, context):
     }
 
 def top_handler(event, context):
-    # DynamoDBから取得する代わりにモックデータを使用
     subjects = get_subjects()
     return {
         "statusCode": 200,
         "headers": {"Content-Type": "application/json"},
         "body": json.dumps(format_response(subjects))
     }
+
+def search_handler(event, context):
+   keyword = event.get('queryStringParameters', {}).get('q', '')
+   subjects = get_subjects()
+   
+   if keyword:
+       filtered_subjects = [
+           s for s in subjects 
+           if keyword in s['subject_name']
+       ]
+   else:
+       filtered_subjects = subjects
+
+   return {
+       "statusCode": 200,
+       "headers": {"Content-Type": "application/json"},
+       "body": json.dumps(format_response(filtered_subjects))
+   }

--- a/app/controller.py
+++ b/app/controller.py
@@ -11,6 +11,7 @@ def health_handler(event, context):
     }
 
 def top_handler(event, context):
+    # DynamoDBから取得する代わりにモックデータを使用
     subjects = get_subjects()
     return {
         "statusCode": 200,

--- a/template.yaml
+++ b/template.yaml
@@ -40,6 +40,20 @@ Resources:
           Properties:
             Path: /top
             Method: get
+  SearchFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Handler: app.controller.search_handler
+      Runtime: python3.9
+      Architectures:
+        - x86_64
+      Events:
+        Search:
+          Type: Api
+          Properties:
+            Path: /search
+            Method: get
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function


### PR DESCRIPTION
概要
- /searchエンドポイントを実装
- 科目名の部分一致検索機能を追加
- AWS SAM設定の更新

変更内
- controller.pyに検索ハンドラーを追加
- template.yamlにSearchFunction設定を追加

テスト結果
- ローカル環境で動作確認済み
- 検索クエリ：/search?q=情報で情報関連科目が正しく返却