### PR TITLE
科目名検索機能の実装

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -18,3 +18,21 @@ def top_handler(event, context):
         "headers": {"Content-Type": "application/json"},
         "body": json.dumps(format_response(subjects))
     }
+
+def search_handler(event, context):
+   keyword = event.get('queryStringParameters', {}).get('q', '')
+   subjects = get_subjects()
+   
+   if keyword:
+       filtered_subjects = [
+           s for s in subjects 
+           if keyword in s['subject_name']
+       ]
+   else:
+       filtered_subjects = subjects
+
+   return {
+       "statusCode": 200,
+       "headers": {"Content-Type": "application/json"},
+       "body": json.dumps(format_response(filtered_subjects))
+   }

--- a/template.yaml
+++ b/template.yaml
@@ -40,7 +40,21 @@ Resources:
           Properties:
             Path: /top
             Method: get
-
+  SearchFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Handler: app.controller.search_handler
+      Runtime: python3.9
+      Architectures:
+        - x86_64
+      Events:
+        Search:
+          Type: Api
+          Properties:
+            Path: /search
+            Method: get
+            
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
   # Find out more about other implicit resources you can reference within SAM
@@ -63,3 +77,12 @@ Outputs:
   TopFunctionIamRole:
     Description: "Implicit IAM Role created for Hello World function"
     Value: !GetAtt TopFunctionRole.Arn
+  SearchApi:
+    Description: "API Gateway endpoint URL for Search function"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/search/"
+  SearchFunction:
+    Description: "Search Lambda Function ARN"
+    Value: !GetAtt SearchFunction.Arn
+  SearchFunctionIamRole:
+    Description: "Implicit IAM Role created for Search function"
+    Value: !GetAtt SearchFunctionRole.Arn


### PR DESCRIPTION
概要

- /searchエンドポイントを実装
- 科目名の部分一致検索機能を追加
- AWS SAM設定の更新

変更内容

- controller.pyに検索ハンドラーを追加
- template.yamlにSearchFunction設定を追加

テスト結果

- ローカル環境で動作確認済み
- 検索クエリ：/search?q=情報で情報関連科目が正しく返却