### PR TITLE
template.yaml と controller.py 内で Top を Subject にリネーム

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -8,9 +8,10 @@ def health_handler(event, context):
         "body": json.dumps({
             "message": "ok"
         }),
+        
     }
 
-def top_handler(event, context):
+def subject_handler(event, context):
     # DynamoDBから取得する代わりにモックデータを使用
     subjects = get_subjects()
     return {

--- a/template.yaml
+++ b/template.yaml
@@ -26,19 +26,19 @@ Resources:
           Properties:
             Path: /health
             Method: get
-  TopFunction:
+  SubjectFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
       CodeUri: .
-      Handler: app.controller.top_handler
+      Handler: app.controller.subject_handler
       Runtime: python3.9
       Architectures:
         - x86_64
       Events:
-        Top:
+        Subject:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
           Properties:
-            Path: /top
+            Path: /subjects
             Method: get
   SearchFunction:
     Type: AWS::Serverless::Function
@@ -83,7 +83,7 @@ Resources:
             Resource: !GetAtt SubjectTable.Arn
       Roles:
         - !Ref HealthFunctionRole
-        - !Ref TopFunctionRole
+        - !Ref SubjectFunctionRole
         - !Ref SearchFunctionRole
             
 Outputs:
@@ -99,15 +99,15 @@ Outputs:
   HealthFunctionIamRole:
     Description: "Implicit IAM Role created for Hello World function"
     Value: !GetAtt HealthFunctionRole.Arn
-  TopApi:
+  SubjectApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/top/"
-  TopFunction:
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/subjects/"
+  SubjectFunction:
     Description: "Hello World Lambda Function ARN"
-    Value: !GetAtt TopFunction.Arn
-  TopFunctionIamRole:
+    Value: !GetAtt SubjectFunction.Arn
+  SubjectFunctionIamRole:
     Description: "Implicit IAM Role created for Hello World function"
-    Value: !GetAtt TopFunctionRole.Arn
+    Value: !GetAtt SubjectFunctionRole.Arn
   SearchApi:
     Description: "API Gateway endpoint URL for Search function"
     Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/search/"


### PR DESCRIPTION
**概要**
template.yaml と controller.py の Top を Subject に変更しました。
template.yaml の 41 行目の Path は /subjects（複数形）に設定しましたが、
それ以外の箇所はすべて単数形 subject に統一しました。

**デプロイと動作確認**
コマンド：sam deploy --guided --profile mini-pbl を使用して開発環境にデプロイしました。
動作確認：以下のエンドポイントで一覧表示が正しく動作することを確認しました。
`https://l3kwbs1v75.execute-api.ap-northeast-1.amazonaws.com/Prod/subjects/`

お手すきの際にご確認お願いします。