### PR TITLE
search_handler関数のheadersにcors設定を追加

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -34,6 +34,9 @@ def search_handler(event, context):
 
    return {
        "statusCode": 200,
-       "headers": {"Content-Type": "application/json"},
+       "headers": {
+           "Content-Type": "application/json",
+           "Access-Control-Allow-Origin": "*"
+       },
        "body": json.dumps(format_response(filtered_subjects))
    }


### PR DESCRIPTION
# 概要
search_handler関数のheadersにcors設定を追加

## 目的
ローカル環境でAPIにアクセスすると、cors設定がないことでブラウザでブロックされ、取得することができない状態になっていたため。