### PR TITLE
科目一覧の表示件数を10件に制限し、/subjectsエンドポイントで科目名表示機能するように修正

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -10,33 +10,24 @@ def health_handler(event, context):
         }),
         
     }
-
+    
 def subject_handler(event, context):
-    # DynamoDBから取得する代わりにモックデータを使用
+    keyword = event.get('queryStringParameters', {}).get('q', '')
     subjects = get_subjects()
+    
+    if keyword:
+        filtered_subjects = [
+            s for s in subjects 
+            if keyword in s['subject_name']
+        ][:10]  # キーワード検索結果の上位10件
+    else:
+        filtered_subjects = subjects[:10]  # 全件取得の場合の上位10件
+    
     return {
         "statusCode": 200,
-        "headers": {"Content-Type": "application/json"},
-        "body": json.dumps(format_response(subjects))
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*"
+        },
+        "body": json.dumps(format_response(filtered_subjects))
     }
-
-def search_handler(event, context):
-   keyword = event.get('queryStringParameters', {}).get('q', '')
-   subjects = get_subjects()
-   
-   if keyword:
-       filtered_subjects = [
-           s for s in subjects 
-           if keyword in s['subject_name']
-       ]
-   else:
-       filtered_subjects = subjects
-
-   return {
-       "statusCode": 200,
-       "headers": {
-           "Content-Type": "application/json",
-           "Access-Control-Allow-Origin": "*"
-       },
-       "body": json.dumps(format_response(filtered_subjects))
-   }

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,35 +1,9 @@
-# More information about the configuration file can be found here:
-# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-config.html
 version = 0.1
-
-[default]
-[default.global.parameters]
-stack_name = "backend-aiit-campus-voice"
-
-[default.build.parameters]
-cached = true
-parallel = true
-
-[default.validate.parameters]
-lint = true
-
 [default.deploy.parameters]
-capabilities = "CAPABILITY_IAM"
-confirm_changeset = true
+stack_name = "backend-aiit-campus-voice"
 resolve_s3 = true
 s3_prefix = "backend-aiit-campus-voice"
 region = "ap-northeast-1"
 profile = "mini-pbl"
+capabilities = "CAPABILITY_IAM"
 image_repositories = []
-
-[default.package.parameters]
-resolve_s3 = true
-
-[default.sync.parameters]
-watch = true
-
-[default.local_start_api.parameters]
-warm_containers = "EAGER"
-
-[default.local_start_lambda.parameters]
-warm_containers = "EAGER"

--- a/template.yaml
+++ b/template.yaml
@@ -40,20 +40,6 @@ Resources:
           Properties:
             Path: /subjects
             Method: get
-  SearchFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: .
-      Handler: app.controller.search_handler
-      Runtime: python3.9
-      Architectures:
-        - x86_64
-      Events:
-        Search:
-          Type: Api
-          Properties:
-            Path: /search
-            Method: get
   SubjectTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -84,7 +70,6 @@ Resources:
       Roles:
         - !Ref HealthFunctionRole
         - !Ref SubjectFunctionRole
-        - !Ref SearchFunctionRole
             
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
@@ -101,22 +86,13 @@ Outputs:
     Value: !GetAtt HealthFunctionRole.Arn
   SubjectApi:
     Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/subjects/"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/subjects?q=subject_name"
   SubjectFunction:
     Description: "Hello World Lambda Function ARN"
     Value: !GetAtt SubjectFunction.Arn
   SubjectFunctionIamRole:
     Description: "Implicit IAM Role created for Hello World function"
     Value: !GetAtt SubjectFunctionRole.Arn
-  SearchApi:
-    Description: "API Gateway endpoint URL for Search function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/search/"
-  SearchFunction:
-    Description: "Search Lambda Function ARN"
-    Value: !GetAtt SearchFunction.Arn
-  SearchFunctionIamRole:
-    Description: "Implicit IAM Role created for Search function"
-    Value: !GetAtt SearchFunctionRole.Arn
   SubjectTable:
     Description: "SubjectTable DynamoDB Table ARN"
     Value: !GetAtt SubjectTable.Arn


### PR DESCRIPTION
変更内容
・科目一覧の表示件数を10件に制限
・エンドポイントの変更

変更前: /search?q=subject_name
変更後: /subjects?q=subject_name

具体的な修正
・科目一覧の表示件数を10件に制限し、/subjectsエンドポイントで科目名の検索ができるように修正しました。

動作確認用URL
・特論で検索する場合の例:
[https://l3kwbs1v75.execute-api.ap-northeast-1.amazonaws.com/Prod/subjects?q=特論](https://l3kwbs1v75.execute-api.ap-northeast-1.amazonaws.com/Prod/subjects?q=%E7%89%B9%E8%AB%96)