### PR TITLE
Display latest 5 reviews when subject_id is not provided, show all wh…

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -77,15 +77,27 @@ Resources:
       TableName: ReviewTable
       AttributeDefinitions:
         - AttributeName: subject_id
-          AttributeType: S
+          AttributeType: S  # 主キー（文字列）
         - AttributeName: id
-          AttributeType: S
+          AttributeType: S  # ソートキー（文字列）
+        - AttributeName: created
+          AttributeType: S  # GSIのソートキー（文字列）
       KeySchema:
         - AttributeName: subject_id
-          KeyType: HASH
+          KeyType: HASH  # 主キー
         - AttributeName: id
-          KeyType: RANGE
+          KeyType: RANGE  # ソートキー
       BillingMode: PAY_PER_REQUEST
+      GlobalSecondaryIndexes:
+        - IndexName: CreatedIndex
+          KeySchema:
+            - AttributeName: subject_id
+              KeyType: HASH
+            - AttributeName: created
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL  # 必要なすべての属性を含める
+  
   DynamoDBAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -101,13 +113,11 @@ Resources:
               - dynamodb:DeleteItem
               - dynamodb:Scan
               - dynamodb:Query
-            Resource: !GetAtt SubjectTable.Arn
+            Resource: !GetAtt ReviewTable.Arn  # 修正：ReviewTableに対応
       Roles:
         - !Ref HealthFunctionRole
         - !Ref SubjectFunctionRole
-      Roles:
-        - !Ref HealthFunctionRole
-        - !Ref SubjectFunctionRole
+
         
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function


### PR DESCRIPTION
修正: subject_idによるレビュー表示ロジックを実装

- subject_idが指定されていない場合、DynamoDBのscanを使用して最新5件を取得
- createdフィールドで降順ソートし、最新のレビューを表示
- subject_idが指定されている場合、GSI（CreatedIndex）を使用して全件取得
- subject_id指定時には件数制限を適用せず、全レビューを表示
- 取得したレビューのデータ形式を統一して処理